### PR TITLE
Develop

### DIFF
--- a/Tests/unit/usuarioController.test.js
+++ b/Tests/unit/usuarioController.test.js
@@ -2,7 +2,17 @@ const UsuarioController = require('../../src/controllers/UsuarioController')
 const Usuario = require('../../src/models/Usuario')
 
 describe('UsuarioController', () => {
-  describe('cadastrar', () => {
+  beforeEach(async () => {
+    // Limpa o banco antes de cada teste para evitar interferências
+    await Usuario.destroy({ where: {} })
+  })
+
+  afterAll(async () => {
+    // Fecha conexão com o banco após os testes
+    await Usuario.sequelize.close()
+  })
+
+  describe('Cadastrar usuário', () => {
     it('deve cadastrar um novo usuário', async () => {
       const req = {
         body: {
@@ -24,6 +34,34 @@ describe('UsuarioController', () => {
         nome: 'Teste',
         email: 'teste@example.com'
       }))
+    })
+  })
+
+  describe('Listar usuários', () => {
+    beforeEach(async () => {
+      await Usuario.create({
+        nome: 'Usuário Teste',
+        email: 'teste@example.com',
+        senha: 'senha123'
+      })
+    })
+
+    it('deve listar todos os usuários', async () => {
+      const req = {} // Nenhum parâmetro necessário para listagem
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn()
+      }
+
+      await UsuarioController.listar(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(200)
+      expect(res.json).toHaveBeenCalledWith(expect.arrayContaining([
+        expect.objectContaining({
+          nome: 'Usuário Teste',
+          email: 'teste@example.com'
+        })
+      ]))
     })
   })
 })

--- a/Tests/unit/usuarioControllerErrors.test.js
+++ b/Tests/unit/usuarioControllerErrors.test.js
@@ -1,0 +1,127 @@
+const UsuarioController = require('../../src/controllers/UsuarioController')
+const Usuario = require('../../src/models/Usuario')
+
+describe('Erros no UsuarioController', () => {
+  beforeEach(async () => {
+    await Usuario.destroy({ where: {} }) // Limpa o banco antes de cada teste
+  })
+
+  afterAll(async () => {
+    await Usuario.sequelize.close() // Fecha conexão com o banco após os testes
+  })
+
+  it('deve retornar 400 ao tentar cadastrar sem nome', async () => {
+    const req = {
+      body: {
+        email: 'teste@example.com',
+        senha: 'senha123'
+      }
+    }
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    }
+
+    await UsuarioController.cadastrar(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ errors: expect.any(Array) })
+    );
+  })
+
+  it('deve retornar 400 ao tentar cadastrar com email inválido', async () => {
+    const req = {
+      body: {
+        nome: 'Usuário Teste',
+        email: 'email-invalido',
+        senha: 'senha123'
+      }
+    };
+
+    const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn()
+      };
+
+    await UsuarioController.cadastrar(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ errors: expect.any(Array) })
+    );
+})  
+  it('deve retornar 409 ao tentar cadastrar com email já existente', async () => {
+    await Usuario.create({
+      nome: 'Usuário Teste',
+      email: 'teste@example.com',
+      senha: 'senha123'
+    })
+
+    const req = {
+      body: {
+        nome: 'Novo Usuário',
+        email: 'teste@example.com', // Mesmo email já cadastrado
+        senha: 'senha123'
+      }
+    }
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    }
+
+    await UsuarioController.cadastrar(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(409)
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      mensagem: 'E-mail já cadastrado!'
+    }))
+  })
+
+  it('deve retornar 400 ao tentar cadastrar com senha menor que 4 caracteres', async () => {
+    const req = {
+      body: {
+        nome: 'Usuário Teste',
+        email: 'teste@example.com',
+        senha: '123'
+      }
+    };
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    };
+
+    await UsuarioController.cadastrar(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ errors: expect.any(Array) })
+    );
+  });
+  it('deve retornar 500 ao ocorrer um erro interno no cadastro', async () => {
+    jest.spyOn(Usuario, 'create').mockRejectedValue(new Error('Erro interno'));
+
+    const req = {
+      body: {
+        nome: 'Usuário Teste',
+        email: 'teste@example.com',
+        senha: 'senha123'
+      }
+    };
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    };
+
+    await UsuarioController.cadastrar(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ erro: 'Não foi possível efetuar o cadastro do usuário.' })
+    );
+  });  
+})

--- a/src/controllers/UsuarioController.js
+++ b/src/controllers/UsuarioController.js
@@ -37,7 +37,7 @@ class UsuarioController {
             })
 
             if (emailExistente) {
-                return res.status(409).json({ mensagem: 'Email já cadastrado!'})
+                return res.status(409).json({ mensagem: 'E-mail já cadastrado!'})
             }
 
             const usuario = await Usuario.create(req.body)


### PR DESCRIPTION
Testes erros cadastro usuarios
 PASS  Tests/unit/usuarioControllerErrors.test.js
  Erros no UsuarioController
    √ deve retornar 400 ao tentar cadastrar sem nome (19 ms)                                                                                                          
    √ deve retornar 400 ao tentar cadastrar com email inválido (6 ms)                                                                                                 
    √ deve retornar 409 ao tentar cadastrar com email já existente (58 ms)                                                                                            
    √ deve retornar 400 ao tentar cadastrar com senha menor que 4 caracteres (5 ms)                                                                                   
    √ deve retornar 500 ao ocorrer um erro interno no cadastro (13 ms)                                                                                                
                                                                                                                                                                      
Test Suites: 1 passed, 1 total                                                                                                                                        
Tests:       5 passed, 5 total                                                                                                                                        
Snapshots:   0 total
Time:        1.705 s, estimated 2 s
Ran all test suites matching /usuarioControllerErrors.test.js/i.