### PR TITLE
Realizado teste de erro de listagem 500

### DIFF
--- a/Tests/unit/usuarioControllerErrors.test.js
+++ b/Tests/unit/usuarioControllerErrors.test.js
@@ -101,6 +101,7 @@ describe('Erros no UsuarioController', () => {
       expect.objectContaining({ errors: expect.any(Array) })
     );
   });
+
   it('deve retornar 500 ao ocorrer um erro interno no cadastro', async () => {
     jest.spyOn(Usuario, 'create').mockRejectedValue(new Error('Erro interno'));
 
@@ -123,5 +124,23 @@ describe('Erros no UsuarioController', () => {
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({ erro: 'Não foi possível efetuar o cadastro do usuário.' })
     );
-  });  
+  });
+
+  it('deve retornar 500 ao ocorrer um erro interno na listagem de usuários', async () => {
+    jest.spyOn(Usuario, 'findAll').mockRejectedValue(new Error('Erro interno'));
+  
+    const req = {};
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    };
+  
+    await UsuarioController.listar(req, res);
+  
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ erro: 'Não foi possível listar os usuários.' })
+    );
+  });
+    
 })


### PR DESCRIPTION
 PASS  Tests/unit/usuarioControllerErrors.test.js
  Erros no UsuarioController
    √ deve retornar 400 ao tentar cadastrar sem nome (16 ms)
    √ deve retornar 400 ao tentar cadastrar com email inválido (7 ms)
    √ deve retornar 409 ao tentar cadastrar com email já existente (39 ms)
    √ deve retornar 400 ao tentar cadastrar com senha menor que 4 caracteres (3 ms)
    √ deve retornar 500 ao ocorrer um erro interno no cadastro (8 ms)
    √ deve retornar 500 ao ocorrer um erro interno na listagem de usuários (3 ms)

Test Suites: 1 passed, 1 total
Tests:       6 passed, 6 total
Snapshots:   0 total
Time:        1.338 s, estimated 2 s
Ran all test suites matching /usuarioControllerErrors.test.js/i.