### PR TITLE
Feature/teste usuario controller errors listar um

### DIFF
--- a/Tests/unit/usuarioControllerErrors.test.js
+++ b/Tests/unit/usuarioControllerErrors.test.js
@@ -142,5 +142,136 @@ describe('Erros no UsuarioController', () => {
       expect.objectContaining({ erro: 'Não foi possível listar os usuários.' })
     );
   });
-    
+
+  it('deve retornar 404 ao tentar listar um usuário inexistente', async () => {
+    const req = { params: { id: 9999 } }; // ID que não existe no banco
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    };
+
+    const result = await UsuarioController.listarUm(req, res);
+    console.log(result, req, res)
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ mensagem: 'Usuário não encontrado!' })
+    );
+  });
+
+  it('deve retornar 500 ao ocorrer um erro interno na busca de um usuário', async () => {
+    jest.spyOn(Usuario, 'findByPk').mockRejectedValue(new Error('Erro interno'));
+
+    const req = { params: { id: 1 } };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    };
+
+    await UsuarioController.listarUm(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ erro: 'Não foi possível listar o usuário.' })
+    );
+  });
+
+  // ====== ATUALIZAR USUÁRIO ======
+  // // it('deve retornar 404 ao tentar atualizar um usuário inexistente', async () => {
+  // //   const req = {
+  // //     params: { id: 999 },
+  // //     body: { nome: 'Novo Nome' }
+  // //   };
+
+  // //   const res = {
+  // //     status: jest.fn().mockReturnThis(),
+  // //     json: jest.fn()
+  // //   };
+
+  // //   await UsuarioController.atualizar(req, res);
+
+  // //   expect(res.status).toHaveBeenCalledWith(404);
+  // //   expect(res.json).toHaveBeenCalledWith(
+  // //     expect.objectContaining({ mensagem: 'Usuário não encontrado!' })
+  // //   );
+  // // });
+
+  // // it('deve retornar 400 ao tentar atualizar com dados inválidos', async () => {
+  // //   const usuarioCriado = await Usuario.create({
+  // //     nome: 'Usuário Teste',
+  // //     email: 'teste@example.com',
+  // //     senha: 'senha123'
+  // //   });
+
+  // //   const req = {
+  // //     params: { id: usuarioCriado.id },
+  // //     body: { nome: '' } // Nome vazio (inválido)
+  // //   };
+
+  // //   const res = {
+  // //     status: jest.fn().mockReturnThis(),
+  // //     json: jest.fn()
+  // //   };
+
+  // //   await UsuarioController.atualizar(req, res);
+
+  // //   expect(res.status).toHaveBeenCalledWith(400);
+  // //   expect(res.json).toHaveBeenCalledWith(
+  // //     expect.objectContaining({ errors: expect.any(Array) })
+  // //   );
+  // // });
+
+  // // it('deve retornar 500 ao ocorrer um erro interno na atualização', async () => {
+  // //   jest.spyOn(Usuario, 'update').mockRejectedValue(new Error('Erro interno'));
+
+  // //   const req = {
+  // //     params: { id: 1 },
+  // //     body: { nome: 'Novo Nome' }
+  // //   };
+
+  // //   const res = {
+  // //     status: jest.fn().mockReturnThis(),
+  // //     json: jest.fn()
+  // //   };
+
+  // //   await UsuarioController.atualizar(req, res);
+
+  // //   expect(res.status).toHaveBeenCalledWith(500);
+  // //   expect(res.json).toHaveBeenCalledWith(
+  // //     expect.objectContaining({ erro: 'Não foi possível atualizar o usuário.' })
+  // //   );
+  // // });
+
+  // // // ====== EXCLUIR USUÁRIO ======
+  // // it('deve retornar 404 ao tentar excluir um usuário inexistente', async () => {
+  // //   const req = { params: { id: 9999 } }; // ID inexistente
+  // //   const res = {
+  // //     status: jest.fn().mockReturnThis(),
+  // //     json: jest.fn()
+  // //   };
+
+  // //   await UsuarioController.excluir(req, res);
+
+  // //   expect(res.status).toHaveBeenCalledWith(404);
+  // //   expect(res.json).toHaveBeenCalledWith(
+  // //     expect.objectContaining({ mensagem: 'Usuário não encontrado!' })
+  // //   );
+  // });
+
+  it('deve retornar 500 ao ocorrer um erro interno na exclusão', async () => {
+    jest.spyOn(Usuario, 'destroy').mockRejectedValue(new Error('Erro interno'));
+
+    const req = { params: { id: 1 } };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    };
+
+    await UsuarioController.excluir(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ erro: 'Não foi possível excluir o usuário.' })
+    );
+  });    
 })

--- a/Tests/unit/usuarioControllerErrors.test.js
+++ b/Tests/unit/usuarioControllerErrors.test.js
@@ -143,15 +143,33 @@ describe('Erros no UsuarioController', () => {
     );
   });
 
+  // it('deve retornar 404 ao tentar listar um usuário inexistente', async () => {
+  //   const req = { params: { id: 9999 } }; // ID que não existe no banco
+  //   const res = {
+  //     status: jest.fn().mockReturnThis(),
+  //     json: jest.fn()
+  //   };
+
+  //   const result = await UsuarioController.listarUm(req, res);
+  //   console.log(result, req, res)
+
+  //   expect(res.status).toHaveBeenCalledWith(404);
+  //   expect(res.json).toHaveBeenCalledWith(
+  //     expect.objectContaining({ mensagem: 'Usuário não encontrado!' })
+  //   );
+  // });
+
   it('deve retornar 404 ao tentar listar um usuário inexistente', async () => {
-    const req = { params: { id: 9999 } }; // ID que não existe no banco
+    const req = { params: { id: 9999 } };
     const res = {
       status: jest.fn().mockReturnThis(),
       json: jest.fn()
     };
 
-    const result = await UsuarioController.listarUm(req, res);
-    console.log(result, req, res)
+    // MOCKANDO O REPOSITÓRIO/ SERVIÇO
+    jest.spyOn(Usuario, 'findOne').mockResolvedValue(null);
+
+    await UsuarioController.listarUm(req, res);
 
     expect(res.status).toHaveBeenCalledWith(404);
     expect(res.json).toHaveBeenCalledWith(

--- a/src/controllers/UsuarioController.js
+++ b/src/controllers/UsuarioController.js
@@ -45,8 +45,7 @@ class UsuarioController {
             
             res.status(201).json(usuario)
 
-        } catch (error) {
-            console.log(error.message)
+        } catch (error) {            
             res.status(500).json({ erro: 'Não foi possível efetuar o cadastro do usuário.'})
         }
     }
@@ -61,9 +60,13 @@ class UsuarioController {
     }
 
     async listarUm(req, res) {
+        // console.log(req, res)
         try {
             const { id } = req.params
-            const usuario = await Usuario.findByPk(id)
+            const idInt = Number(id); // Converte para número
+            const usuario = await Usuario.findByPk(idInt)
+
+            console.log("Usuário encontrado:", usuario);
 
             if(!usuario) {
                 return res.status(404).json({ mensagem: 'Usuário não encontrado!'})
@@ -72,8 +75,8 @@ class UsuarioController {
             res.status(200).json(usuario)
             
         } catch (error) {
-            console.log(error.message)
-            res.status(500).json({ erro: 'Não foi possível listar o usuário'})
+            // console.error(error);
+            res.status(500).json({ erro: 'Não foi possível listar o usuário.' })
         }
     }
 


### PR DESCRIPTION
 PASS  Tests/unit/usuarioControllerErrors.test.js
  Erros no UsuarioController
    √ deve retornar 400 ao tentar cadastrar sem nome (25 ms)                                                            
    √ deve retornar 400 ao tentar cadastrar com email inválido (9 ms)                                                   
    √ deve retornar 409 ao tentar cadastrar com email já existente (56 ms)                                              
    √ deve retornar 400 ao tentar cadastrar com senha menor que 4 caracteres (3 ms)                                     
    √ deve retornar 500 ao ocorrer um erro interno no cadastro (10 ms)                                                  
    √ deve retornar 500 ao ocorrer um erro interno na listagem de usuários (3 ms)                                       
    √ deve retornar 404 ao tentar listar um usuário inexistente (9 ms)                                                  
    √ deve retornar 500 ao ocorrer um erro interno na busca de um usuário (4 ms)                                        
    √ deve retornar 500 ao ocorrer um erro interno na exclusão (4 ms)                                                   
                                                                                                                        
Test Suites: 1 passed, 1 total
Tests:       9 passed, 9 total
Snapshots:   0 total
    Executing (default): DELETE FROM "usuarios"