### PR TITLE
Testes usuario controller erros

### DIFF
--- a/src/controllers/UsuarioController.js
+++ b/src/controllers/UsuarioController.js
@@ -92,7 +92,8 @@ class UsuarioController {
             }
 
             const { id } = req.params
-            const usuario = await Usuario.findByPk(id)
+            const idInt = Number(id); // Converte para número
+            const usuario = await Usuario.findByPk(idInt)
 
             if(!usuario) {
                 return res.status(404).json({ mensagem: 'Usuário não encontrado!'})


### PR DESCRIPTION
 PASS  Tests/unit/usuarioControllerErrors.test.js
  Erros no UsuarioController
    √ deve retornar 400 ao tentar cadastrar sem nome (19 ms)                                                                                                          
    √ deve retornar 400 ao tentar cadastrar com email inválido (8 ms)                                                                                                 
    √ deve retornar 409 ao tentar cadastrar com email já existente (52 ms)                                                                                            
    √ deve retornar 400 ao tentar cadastrar com senha menor que 4 caracteres (5 ms)                                                                                   
    √ deve retornar 500 ao ocorrer um erro interno no cadastro (10 ms)                                                                                                
    √ deve retornar 500 ao ocorrer um erro interno na listagem de usuários (4 ms)                                                                                     
    √ deve retornar 404 ao tentar listar um usuário inexistente (7 ms)                                                                                                
    √ deve retornar 500 ao ocorrer um erro interno na busca de um usuário (4 ms)                                                                                      
    √ deve retornar 404 ao tentar atualizar um usuário inexistente (5 ms)                                                                                             
    √ deve retornar 400 ao tentar atualizar com dados inválidos (30 ms)                                                                                               
    √ deve retornar 500 ao ocorrer um erro interno na atualização (65 ms)                                                                                             
    √ deve retornar 404 ao tentar excluir um usuário inexistente (3 ms)
    √ deve retornar 500 ao ocorrer um erro interno na exclusão (3 ms)

Test Suites: 1 passed, 1 total
Tests:       13 passed, 13 total
Snapshots:   0 total
Time:        1.692 s, estimated 2 s
Ran all test suites matching /usuarioControllerErrors.test.js/i.