### PR TITLE
Testes TipoMov Routes

### DIFF
--- a/Tests/integration/tipoMovRoutes.test.js
+++ b/Tests/integration/tipoMovRoutes.test.js
@@ -1,0 +1,167 @@
+const request = require('supertest');
+const { Server } = require('../../src/server');
+const { connection } = require('../../src/database/connection');
+const jwt = require('jsonwebtoken');
+const serverInstance = new Server();
+const Usuario = require('../../src/models/Usuario');
+const TipoMov = require('../../src/models/TipoMov');
+
+describe('Testes de Integração - TipoMovController', () => {
+    let app;
+    let tipoMovCriado;
+    let token;
+    let usuarioCriado;        
+
+    beforeAll(async () => {
+        app = serverInstance.getApp(); // Obtenha o app (servidor Express)
+        await connection.sync({ force: true }); // Limpa o banco e recria as tabelas
+        usuarioCriado = await Usuario.create({ nome: "Usuário Teste", email: "teste@email.com", senha: "12345" });        
+        console.log('Usuário criado:', usuarioCriado);
+        token = jwt.sign({ id: usuarioCriado.id, nome: usuarioCriado.nome }, process.env.SECRET_JWT, { expiresIn: '5h' });
+    }); 
+
+    beforeEach(async () => {
+        await connection.sync({ force: true }); // Limpa o banco antes de cada teste
+        usuarioCriado = await Usuario.create({ nome: "Usuário Teste", email: "teste@email.com", senha: "12345" });        
+        const response = await request(app)
+            .post('/tipomov')
+            .set('Authorization', token) // Inclui o token no cabeçalho Authorization
+            .send({
+                nome_tipo_mov: 'Tipo de Movimento Teste',
+                usuario_id: usuarioCriado.id
+            });
+        
+        tipoMovCriado = response.body;
+    });
+
+    afterAll(async () => {
+        await connection.close(); // Fecha a conexão após os testes
+    });
+
+    // ✅ Teste de cadastro
+    describe('POST /tipomov', () => {
+        it('deve cadastrar um novo tipo de movimento', async () => {
+            const response = await request(app)
+                .post('/tipomov')
+                .set('Authorization', token)
+                .send({
+                    nome_tipo_mov: 'Tipo de Movimento Teste Novo',
+                    usuario_id: usuarioCriado.id
+                });
+
+            expect(response.status).toBe(201);
+            expect(response.body).toHaveProperty('nome_tipo_mov', 'Tipo de Movimento Teste Novo');
+            expect(response.body).toHaveProperty('usuario_id', usuarioCriado.id);
+        });
+
+        it('deve retornar erro ao cadastrar tipo de movimento duplicado', async () => {
+            const response = await request(app)
+                .post('/tipomov')
+                .set('Authorization', token)
+                .send({
+                    nome_tipo_mov: "Tipo de Movimento Teste",
+                    usuario_id: usuarioCriado.id
+                });
+
+            expect(response.status).toBe(409);
+            expect(response.body).toHaveProperty('mensagem', 'Tipo de movimento já cadastrado!');
+        });
+    });
+
+    // ✅ Teste de listar todos
+    describe('GET /tipomov', () => {
+        it('deve listar todos os tipos de movimento', async () => {
+            const response = await request(app)
+                .get('/tipomov')
+                .set('Authorization', token)
+
+            expect(response.status).toBe(200);
+            expect(response.body).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        nome_tipo_mov: 'Tipo de Movimento Teste',
+                        usuario_id: usuarioCriado.id
+                    })
+                ])
+            );
+        });
+    });
+
+    // ✅ Teste de listar um
+    describe('GET /tipomov/:id', () => {
+        it('deve listar um tipo de movimento pelo ID', async () => {
+            const response = await request(app)
+                .get(`/tipomov/${tipoMovCriado.id}`)
+                .set('Authorization', token)
+
+            expect(response.status).toBe(200);
+            expect(response.body).toHaveProperty('id', tipoMovCriado.id);
+            expect(response.body).toHaveProperty('nome_tipo_mov', 'Tipo de Movimento Teste');
+        });
+
+        it('deve retornar erro se o tipo de movimento não for encontrado', async () => {
+            const response = await request(app)
+                .get('/tipomov/999')
+                .set('Authorization', token)
+
+            expect(response.status).toBe(404);
+            expect(response.body).toHaveProperty('mensagem', 'Tipo de movimento não encontrado!');
+        });
+    });
+
+    // ✅ Teste de atualização
+    describe('PUT /tipomov/:id', () => {
+        it('deve atualizar um tipo de movimento específico', async () => {
+            const response = await request(app)
+                .put(`/tipomov/${tipoMovCriado.id}`)
+                .set('Authorization', token)
+                .send({
+                    nome_tipo_mov: 'Nome Atualizado',
+                    usuario_id: usuarioCriado.id
+                });
+
+            expect(response.status).toBe(200);
+            expect(response.body).toHaveProperty('mensagem', 'Alteração efetuada com sucesso!');
+        });
+
+        it('deve retornar erro ao tentar atualizar um tipo de movimento inexistente', async () => {
+            const response = await request(app)
+                .put('/tipomov/999')
+                .set('Authorization', token)
+                .send({
+                    nome_tipo_mov: 'Novo Nome',
+                    usuario_id: usuarioCriado.id
+                });
+
+            expect(response.status).toBe(404);
+            expect(response.body).toHaveProperty('mensagem', 'Tipo de movimento não encontrado!');
+        });
+    });
+
+    // ✅ Teste de exclusão
+    describe('DELETE /tipomov/:id', () => {
+        it('deve excluir um tipo de movimento específico', async () => {
+            const response = await request(app)
+                .delete(`/tipomov/${tipoMovCriado.id}`)
+                .set('Authorization', token)
+
+            expect(response.status).toBe(200);
+            expect(response.body).toHaveProperty('mensagem', 'Tipo de movimento excluído com sucesso!');
+
+            // Verifica se foi realmente excluído
+            const verificaTipoMov = await request(app)
+                .get(`/tipomov/${tipoMovCriado.id}`)
+                .set('Authorization', token)
+            expect(verificaTipoMov.status).toBe(404);
+        });
+        
+        it('deve retornar erro ao tentar excluir um tipo de movimento inexistente', async () => {
+            const response = await request(app)
+                .delete('/tipomov/999')
+                .set('Authorization', token)
+
+            expect(response.status).toBe(404);
+            expect(response.body).toHaveProperty('mensagem', 'Tipo de movimento não encontrado!');
+        });
+    });
+});

--- a/Tests/unit/tipoMovController.test.js
+++ b/Tests/unit/tipoMovController.test.js
@@ -1,0 +1,166 @@
+const TipoMovController = require('../../src/controllers/TipoMovController')
+const TipoMov = require('../../src/models/TipoMov')
+const Usuario = require('../../src/models/Usuario')
+
+describe('TipoMovController', () => {
+  beforeAll(async () =>{
+    await Usuario.create({ id: 2 , nome: "Usuário Teste", email: "teste@email.com", senha: "12345" });
+  })
+
+  beforeEach(async () => {
+    // Limpa o banco antes de cada teste para evitar interferências
+    await TipoMov.destroy({ where: {} })  
+    
+  })
+
+  afterAll(async () => {
+    // Fecha conexão com o banco após os testes
+    await TipoMov.sequelize.close()
+  })
+
+  describe('Cadastrar tipo de movimento', () => {
+    it('deve cadastrar um novo tipo de movimento', async () => {
+      const req = {
+        body: {
+          nome_tipo_mov: 'Teste',
+          usuario_id: 2          
+        }
+      }
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn()
+      }
+
+      await TipoMovController.cadastrar(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(201)
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+        nome_tipo_mov: 'Teste',
+        usuario_id: 2        
+      }))
+    })
+  })
+
+  describe('Listar tipos de movimentos', () => {
+    beforeEach(async () => {
+      await TipoMov.create({
+        nome_tipo_mov: 'Tipo de movimento Teste',
+        usuario_id: 2        
+      })
+    })
+
+    it('deve listar todos os tipos de movimentos', async () => {
+      const req = {} // Nenhum parâmetro necessário para listagem
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn()
+      }
+
+      await TipoMovController.listar(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(200)
+      expect(res.json).toHaveBeenCalledWith(expect.arrayContaining([
+        expect.objectContaining({
+          nome_tipo_mov: 'Tipo de movimento Teste',
+          usuario_id: 2
+        })
+      ]))
+    })
+  })
+
+  describe('Listar um tipo de movimento específico', () => {
+    let tipoMovCriado
+
+    beforeEach(async () => {
+        tipoMovCriado = await TipoMov.create({
+          nome_tipo_mov: 'Tipo de movimento Teste',
+          usuario_id: 2
+      })
+    })
+
+    it('deve listar um tipo de movimento específico', async () => {
+      const req = { params: { id: tipoMovCriado.id } };
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn()
+      }
+
+      await TipoMovController.listarUm(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(200)
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: tipoMovCriado.id,
+          nome_tipo_mov: 'Tipo de movimento Teste',
+          usuario_id: 2
+        })
+      );
+    })
+  })
+
+  describe('Atualizar tipo de movimento', () => {
+    let tipoMovCriado
+
+    beforeEach(async () => {
+      tipoMovCriado = await TipoMov.create({
+        nome_tipo_mov: 'Tipo de movimento Teste',
+        usuario_id: 2
+      })
+    })
+
+    it('deve atualizar um tipo de movimento específico', async () => {
+      const req = { 
+        params: { id: tipoMovCriado.id },
+        body: {
+          nome_tipo_mov: 'Novo tipo Mov',
+          usuario_id: 2
+        }
+      };
+        
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn()
+      }
+
+      await TipoMovController.atualizar(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(200)
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ mensagem: 'Alteração efetuada com sucesso!' })
+      );
+
+      const tipoMovAtualizado = await TipoMov.findByPk(tipoMovCriado.id);
+      expect(tipoMovAtualizado.nome_tipo_mov).toBe('Novo tipo Mov')      
+    })
+  })
+
+  describe('Excluir tipo de movimento', () => {
+    let tipoMovCriado
+
+    beforeEach(async () => {
+      tipoMovCriado = await TipoMov.create({
+        nome_tipo_mov: 'Tipo de movimento Teste',
+        usuario_id: 2
+      })
+    })
+    
+    it('deve excluir um tipo de movimento específico', async () => {      
+      const req = { params: { id: tipoMovCriado.id } };
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn()
+      }
+
+      await TipoMovController.excluir(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(200)
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ mensagem: 'Tipo de movimento excluído com sucesso!' })
+      ); 
+      
+      const tipoMovDeletado = await TipoMov.findByPk(tipoMovCriado.id);
+      expect(tipoMovDeletado).toBeNull();
+    })
+  })  
+})

--- a/src/controllers/TipoMovController.js
+++ b/src/controllers/TipoMovController.js
@@ -16,6 +16,7 @@ class TipoMovController {
             await body('usuario_id').isInt().withMessage('Informe o usuário').run(req)
                 
             const errors = validationResult(req)
+            console.log('Erros de Validação:', errors.array());
             if (!errors.isEmpty()) {
                 return res.status(400).json({ errors: errors.array() })
             }
@@ -58,7 +59,7 @@ class TipoMovController {
             const tipoMov = await TipoMov.findByPk(id)
 
             if (!tipoMov) {
-                return res.status(404).json({ erro: "Tipo de movimento não encontrado." });
+                return res.status(404).json({ mensagem: "Tipo de movimento não encontrado!" });
             }
 
             res.status(200).json(tipoMov)
@@ -80,6 +81,10 @@ class TipoMovController {
 
             const { id } = req.params
             const tipoMov = await TipoMov.findByPk(id)
+
+            if (!tipoMov) {
+                return res.status(404).json({ mensagem: "Tipo de movimento não encontrado!" });
+            }
 
             const tipoMovExistente = await TipoMov.findOne({
                 where: {
@@ -111,15 +116,16 @@ class TipoMovController {
                 }
             })
 
+            const tipoMov = await TipoMov.findByPk(id)
+
             if (!tipoMov) {
-                return res.status(404).json({ erro: "Tipo de movimento não encontrado." });
+                return res.status(404).json({ mensagem: "Tipo de movimento não encontrado!" });
             }
 
             if (classeVinculada) {
                 return res.status(400).json({ erro: 'Este tipo de movimento está vinculado a uma classe e não pode ser excluído.' })
             }
-
-            const tipoMov = await TipoMov.findByPk(id)
+            
             await tipoMov.destroy()            
             res.status(200).json({ mensagem: 'Tipo de movimento excluído com sucesso!'})
 


### PR DESCRIPTION
 PASS  Tests/integration/tipoMovRoutes.test.js
  Testes de Integração - TipoMovController
    POST /tipomov                                                                                                                                                    
      √ deve cadastrar um novo tipo de movimento (232 ms)                                                                                                            
      √ deve retornar erro ao cadastrar tipo de movimento duplicado (180 ms)                                                                                         
    GET /tipomov                                                                                                                                                     
      √ deve listar todos os tipos de movimento (179 ms)                                                                                                             
    GET /tipomov/:id                                                                                                                                                 
      √ deve listar um tipo de movimento pelo ID (217 ms)                                                                                                            
      √ deve retornar erro se o tipo de movimento não for encontrado (169 ms)                                                                                        
    PUT /tipomov/:id                                                                                                                                                 
      √ deve atualizar um tipo de movimento específico (173 ms)                                                                                                      
      √ deve retornar erro ao tentar atualizar um tipo de movimento inexistente (162 ms)                                                                             
    DELETE /tipomov/:id                                                                                                                                              
      √ deve excluir um tipo de movimento específico (169 ms)                                                                                                        
      √ deve retornar erro ao tentar excluir um tipo de movimento inexistente (167 ms)                                                                               
                                                                                                                                                                     
Test Suites: 1 passed, 1 total                                                                                                                                       
Tests:       9 passed, 9 total                                                                                                                                       
Snapshots:   0 total
Time:        3.645 s, estimated 4 s
Ran all test suites matching /tipoMovRoutes.test.js/i.