### PR TITLE
Teste de erros em TipoMovController.

### DIFF
--- a/Tests/unit/tipoMovControllerErrors.test.js
+++ b/Tests/unit/tipoMovControllerErrors.test.js
@@ -1,0 +1,171 @@
+const TipoMovController = require("../../src/controllers/TipoMovController");
+const TipoMov = require("../../src/models/TipoMov");
+const Usuario = require("../../src/models/Usuario");
+
+describe("Erros no TipoMovController", () => {
+  beforeAll(async () => {
+    await Usuario.create({
+      id: 2,
+      nome: "Usuário Teste",
+      email: "teste@email.com",
+      senha: "12345",
+    });
+  });
+
+  beforeEach(async () => {
+    jest.restoreAllMocks(); // Restaura todos os mocks antes de cada teste
+    await TipoMov.destroy({ where: {} }); // Limpa o banco antes de cada teste
+  });
+
+  afterAll(async () => {
+    await TipoMov.sequelize.close(); // Fecha conexão com o banco após os testes
+  });
+
+  it("deve retornar 400 ao tentar cadastrar sem nome", async () => {
+    const req = {
+      body: {
+        nome_tipo_mov: "",
+        usuario_id: 2,
+      },
+    };
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    await TipoMovController.cadastrar(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ errors: expect.any(Array) })
+    );
+  });
+
+  it("deve retornar 409 ao tentar cadastrar com descricao já existente", async () => {
+    await TipoMov.create({
+      nome_tipo_mov: "Teste",
+      usuario_id: 2,
+    });
+
+    const req = {
+      body: {
+        nome_tipo_mov: "Teste",
+        usuario_id: 2,
+      },
+    };
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    await TipoMovController.cadastrar(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ mensagem: "Tipo de movimento já cadastrado!" })
+    );
+  });
+
+  it("deve retornar 500 ao ocorrer um erro interno no cadastro", async () => {
+    jest.spyOn(TipoMov, "create").mockRejectedValue(new Error("Erro interno"));
+
+    const req = {
+      body: {
+        nome_tipo_mov: "Teste",
+        usuario_id: 2,
+      },
+    };
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    await TipoMovController.cadastrar(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        erro: "Não foi possível efetuar o cadastro do tipo de movimento.",
+      })
+    );
+  });
+
+  it("deve retornar 404 ao tentar listar um tipoMov inexistente", async () => {
+    const req = { params: { id: 9999 } };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    jest.spyOn(TipoMov, "findByPk").mockResolvedValue(null);
+
+    await TipoMovController.listarUm(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ mensagem: "Tipo de movimento não encontrado!" })
+    );
+  });
+
+  it("deve retornar 500 ao ocorrer um erro interno na busca de um tipoMov", async () => {
+    jest
+      .spyOn(TipoMov, "findByPk")
+      .mockRejectedValue(new Error("Erro interno"));
+
+    const req = { params: { id: 1 } };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    await TipoMovController.listarUm(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        erro: "Não foi possível listar o tipo de movimento.",
+      })
+    );
+  });
+
+  it("deve retornar 404 ao tentar excluir um tipoMov inexistente", async () => {
+    const req = { params: { id: 9999 } };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    jest.spyOn(TipoMov, "findByPk").mockResolvedValue(null);
+
+    await TipoMovController.excluir(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ mensagem: "Tipo de movimento não encontrado!" })
+    );
+  });
+
+  it("deve retornar 500 ao ocorrer um erro interno na exclusão", async () => {
+    jest.spyOn(TipoMov, "findByPk").mockResolvedValue({
+      destroy: jest.fn().mockRejectedValue(new Error("Erro interno")),
+    });
+
+    const req = { params: { id: 1 } };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    await TipoMovController.excluir(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        erro: "Não foi possível excluir o tipo de movimento.",
+      })
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "jest",
+    "test": "jest --runInBand",
     "start": "nodemon src/index.js"
   },
   "keywords": [],

--- a/src/controllers/ClasseController.js
+++ b/src/controllers/ClasseController.js
@@ -124,11 +124,9 @@ class ClasseController {
       });
 
       if (movimentoVinculado) {
-        return res
-          .status(400)
-          .json({
-            erro: "Esta classe está vinculada a um movimento e não pode ser excluída.",
-          });
+        return res.status(400).json({
+          erro: "Esta classe está vinculada a um movimento e não pode ser excluída.",
+        });
       }
 
       const classe = await Classe.findByPk(id);

--- a/src/controllers/ContaController.js
+++ b/src/controllers/ContaController.js
@@ -109,11 +109,9 @@ class ContaController {
       });
 
       if (movimentoVinculado) {
-        return res
-          .status(400)
-          .json({
-            erro: "Esta conta está vinculada a um movimento e não pode ser excluída.",
-          });
+        return res.status(400).json({
+          erro: "Esta conta está vinculada a um movimento e não pode ser excluída.",
+        });
       }
 
       const conta = await Conta.findByPk(id);

--- a/src/controllers/TipoMovController.js
+++ b/src/controllers/TipoMovController.js
@@ -49,11 +49,9 @@ class TipoMovController {
       res.status(201).json(tipoMov);
     } catch (error) {
       console.log(error.message);
-      res
-        .status(500)
-        .json({
-          erro: "Não foi possível efetuar o cadastro do tipo de movimento.",
-        });
+      res.status(500).json({
+        erro: "Não foi possível efetuar o cadastro do tipo de movimento.",
+      });
     }
   }
 
@@ -152,11 +150,9 @@ class TipoMovController {
       }
 
       if (classeVinculada) {
-        return res
-          .status(400)
-          .json({
-            erro: "Este tipo de movimento está vinculado a uma classe e não pode ser excluído.",
-          });
+        return res.status(400).json({
+          erro: "Este tipo de movimento está vinculado a uma classe e não pode ser excluído.",
+        });
       }
 
       await tipoMov.destroy();


### PR DESCRIPTION
 PASS  Tests/unit/tipoMovControllerErrors.test.js
  Erros no TipoMovController                                                                                                      
    √ deve retornar 400 ao tentar cadastrar sem nome (13 ms)                                                                      
    √ deve retornar 409 ao tentar cadastrar com descricao já existente (17 ms)                                                    
    √ deve retornar 500 ao ocorrer um erro interno no cadastro (13 ms)                                                            
    √ deve retornar 404 ao tentar listar um tipoMov inexistente (3 ms)                                                            
    √ deve retornar 500 ao ocorrer um erro interno na busca de um tipoMov (4 ms)                                                  
    √ deve retornar 404 ao tentar excluir um tipoMov inexistente (4 ms)                                                           
    √ deve retornar 500 ao ocorrer um erro interno na exclusão (4 ms)                                                             
                                                                                                                                  
Test Suites: 1 passed, 1 total
Tests:       7 passed, 7 total
Snapshots:   0 total
Time:        1.308 s, estimated 2 s
Ran all test suites matching /tipoMovControllerErrors.test.js/i.