### PR TITLE
Feature/testes conta controller erros

### DIFF
--- a/Tests/unit/contaControllerErrors.test.js
+++ b/Tests/unit/contaControllerErrors.test.js
@@ -1,0 +1,169 @@
+const ContaController = require("../../src/controllers/ContaController");
+const Conta = require("../../src/models/Conta");
+const Usuario = require("../../src/models/Usuario");
+
+describe("Erros no ContaController", () => {
+  beforeAll(async () => {
+    await Usuario.create({
+      id: 2,
+      nome: "Usuário Teste",
+      email: "teste@email.com",
+      senha: "12345",
+    });
+  });
+
+  beforeEach(async () => {
+    jest.restoreAllMocks(); // Restaura todos os mocks antes de cada teste
+    await Conta.destroy({ where: {} }); // Limpa o banco antes de cada teste
+  });
+
+  afterAll(async () => {
+    await Conta.sequelize.close(); // Fecha conexão com o banco após os testes
+  });
+
+  it("deve retornar 400 ao tentar cadastrar sem nome", async () => {
+    const req = {
+      body: {
+        nome_conta: "",
+        usuario_id: 2,
+      },
+    };
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    await ContaController.cadastrar(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ errors: expect.any(Array) })
+    );
+  });
+
+  it("deve retornar 409 ao tentar cadastrar com descricao já existente", async () => {
+    await Conta.create({
+      nome_conta: "Teste",
+      usuario_id: 2,
+    });
+
+    const req = {
+      body: {
+        nome_conta: "Teste",
+        usuario_id: 2,
+      },
+    };
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    await ContaController.cadastrar(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ mensagem: "Conta já cadastrada!" })
+    );
+  });
+
+  it("deve retornar 500 ao ocorrer um erro interno no cadastro", async () => {
+    jest.spyOn(Conta, "create").mockRejectedValue(new Error("Erro interno"));
+
+    const req = {
+      body: {
+        nome_conta: "Teste",
+        usuario_id: 2,
+      },
+    };
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    await ContaController.cadastrar(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        erro: "Não foi possível cadastrar a conta.",
+      })
+    );
+  });
+
+  it("deve retornar 404 ao tentar listar uma conta inexistente", async () => {
+    const req = { params: { id: 9999 } };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    jest.spyOn(Conta, "findByPk").mockResolvedValue(null);
+
+    await ContaController.listarUm(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ mensagem: "Conta não encontrada!" })
+    );
+  });
+
+  it("deve retornar 500 ao ocorrer um erro interno na busca de uma conta", async () => {
+    jest.spyOn(Conta, "findByPk").mockRejectedValue(new Error("Erro interno"));
+
+    const req = { params: { id: 1 } };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    await ContaController.listarUm(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        erro: "Não foi possível listar a conta.",
+      })
+    );
+  });
+
+  it("deve retornar 404 ao tentar excluir uma conta inexistente", async () => {
+    const req = { params: { id: 9999 } };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    jest.spyOn(Conta, "findByPk").mockResolvedValue(null);
+
+    await ContaController.excluir(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ mensagem: "Conta não encontrada!" })
+    );
+  });
+
+  it("deve retornar 500 ao ocorrer um erro interno na exclusão", async () => {
+    jest.spyOn(Conta, "findByPk").mockResolvedValue({
+      destroy: jest.fn().mockRejectedValue(new Error("Erro interno")),
+    });
+
+    const req = { params: { id: 1 } };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    await ContaController.excluir(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        erro: "Não foi possível excluir a conta.",
+      })
+    );
+  });
+});

--- a/src/controllers/ContaController.js
+++ b/src/controllers/ContaController.js
@@ -1,25 +1,25 @@
-const Conta = require('../models/Conta');
-const Movimento = require('../models/Movimento');
-const { Op } = require('sequelize');
-const { body, validationResult } = require('express-validator');
+const Conta = require("../models/Conta");
+const Movimento = require("../models/Movimento");
+const { Op } = require("sequelize");
+const { body, validationResult } = require("express-validator");
 
 class ContaController {
   async cadastrar(req, res) {
     try {
-      await body('nome_conta')
+      await body("nome_conta")
         .notEmpty()
-        .withMessage('O nome é obrigatório')
+        .withMessage("O nome é obrigatório")
         .custom((value) => {
           if (value.trim().length === 0) {
-            throw new Error('O nome não pode conter apenas espaços em branco');
+            throw new Error("O nome não pode conter apenas espaços em branco");
           }
           return true;
         })
         .run(req);
 
-      await body('usuario_id')
+      await body("usuario_id")
         .isInt()
-        .withMessage('Informe o usuário')
+        .withMessage("Informe o usuário")
         .run(req);
 
       const errors = validationResult(req);
@@ -32,7 +32,7 @@ class ContaController {
       if (!nome_conta) {
         return res
           .status(400)
-          .json({ erro: 'Todos os campos devem ser preenchidos!' });
+          .json({ erro: "Todos os campos devem ser preenchidos!" });
       }
 
       const contaExistente = await Conta.findOne({
@@ -42,14 +42,14 @@ class ContaController {
       });
 
       if (contaExistente) {
-        return res.status(409).json({ mensagem: 'Conta já cadastrada!' });
+        return res.status(409).json({ mensagem: "Conta já cadastrada!" });
       }
 
       const conta = await Conta.create(req.body);
 
       res.status(201).json(conta);
-    } catch (error) {;      
-      res.status(500).json({ erro: 'Não foi possível cadastrar a conta.' });
+    } catch (error) {
+      res.status(500).json({ erro: "Não foi possível cadastrar a conta." });
     }
   }
 
@@ -58,7 +58,7 @@ class ContaController {
       const contas = await Conta.findAll();
       res.status(200).json(contas);
     } catch (error) {
-      res.status(500).json({ erro: 'Não foi possível listar as contas.' });
+      res.status(500).json({ erro: "Não foi possível listar as contas." });
     }
   }
 
@@ -67,9 +67,13 @@ class ContaController {
       const { id } = req.params;
       const conta = await Conta.findByPk(id);
 
+      if (!conta) {
+        return res.status(404).json({ mensagem: "Conta não encontrada!" });
+      }
+
       res.status(200).json(conta);
-    } catch (error) {      
-      res.status(500).json({ erro: 'Não foi possível listar a conta.' });
+    } catch (error) {
+      res.status(500).json({ erro: "Não foi possível listar a conta." });
     }
   }
 
@@ -86,15 +90,15 @@ class ContaController {
       });
 
       if (contaExistente) {
-        return res.status(409).json({ mensagem: 'Conta já cadastrada!' });
+        return res.status(409).json({ mensagem: "Conta já cadastrada!" });
       }
 
       await conta.update(req.body);
       await conta.save();
 
-      res.status(200).json({ mensagem: 'Alteração efetuada com sucesso!' });
+      res.status(200).json({ mensagem: "Alteração efetuada com sucesso!" });
     } catch (error) {
-      res.status(500).json({ erro: 'Não foi possível atualizar a conta.' });
+      res.status(500).json({ erro: "Não foi possível atualizar a conta." });
     }
   }
 
@@ -110,20 +114,20 @@ class ContaController {
       });
 
       if (!conta) {
-        return res.status(404).json({ erro: 'Conta não encontrada.' });
+        return res.status(404).json({ mensagem: "Conta não encontrada!" });
       }
 
       if (movimentoVinculado) {
         return res.status(400).json({
-          erro: 'Esta conta está vinculada a um movimento e não pode ser excluída.',
+          erro: "Esta conta está vinculada a um movimento e não pode ser excluída.",
         });
       }
 
       await conta.destroy();
 
-      res.status(200).json({ mensagem: 'Conta excluída com sucesso!' });
+      res.status(200).json({ mensagem: "Conta excluída com sucesso!" });
     } catch (error) {
-      res.status(500).json({ erro: 'Não foi possível excluir a conta.' });
+      res.status(500).json({ erro: "Não foi possível excluir a conta." });
     }
   }
 }

--- a/src/controllers/TipoMovController.js
+++ b/src/controllers/TipoMovController.js
@@ -1,31 +1,31 @@
-const TipoMov = require('../models/TipoMov');
-const Classe = require('../models/Classe');
-const { body, validationResult } = require('express-validator');
-const { Op } = require('sequelize');
+const TipoMov = require("../models/TipoMov");
+const Classe = require("../models/Classe");
+const { body, validationResult } = require("express-validator");
+const { Op } = require("sequelize");
 
 class TipoMovController {
   async cadastrar(req, res) {
     try {
-      await body('nome_tipo_mov')
+      await body("nome_tipo_mov")
         .notEmpty()
-        .withMessage('Informe o nome do tipo de movimento.')
+        .withMessage("Informe o nome do tipo de movimento.")
         .custom((value) => {
           if (value.trim().length === 0) {
             throw new Error(
-              'O tipo de movimento não pode conter apenas espaços em branco'
+              "O tipo de movimento não pode conter apenas espaços em branco"
             );
           }
           return true;
         })
         .run(req);
 
-      await body('usuario_id')
+      await body("usuario_id")
         .isInt()
-        .withMessage('Informe o usuário')
+        .withMessage("Informe o usuário")
         .run(req);
 
       const errors = validationResult(req);
-      console.log('Erros de Validação:', errors.array());
+      console.log("Erros de Validação:", errors.array());
       if (!errors.isEmpty()) {
         return res.status(400).json({ errors: errors.array() });
       }
@@ -36,12 +36,12 @@ class TipoMovController {
         },
       });
 
-      console.log('TipoMov Existente:', tipoMovExistente);
+      console.log("TipoMov Existente:", tipoMovExistente);
 
       if (tipoMovExistente) {
         return res
           .status(409)
-          .json({ mensagem: 'Tipo de movimento já cadastrado!' });
+          .json({ mensagem: "Tipo de movimento já cadastrado!" });
       }
 
       const tipoMov = await TipoMov.create(req.body);
@@ -50,7 +50,7 @@ class TipoMovController {
     } catch (error) {
       console.log(error.message);
       res.status(500).json({
-        erro: 'Não foi possível efetuar o cadastro do tipo de movimento.',
+        erro: "Não foi possível efetuar o cadastro do tipo de movimento.",
       });
     }
   }
@@ -58,12 +58,12 @@ class TipoMovController {
   async listar(req, res) {
     try {
       const tiposMov = await TipoMov.findAll();
-      console.log('Tipos de Movimento no BD:', tiposMov);
+      console.log("Tipos de Movimento no BD:", tiposMov);
       res.status(200).json(tiposMov);
     } catch (error) {
       res
         .status(500)
-        .json({ erro: 'Não foi possível listar os tipos de movimentos.' });
+        .json({ erro: "Não foi possível listar os tipos de movimentos." });
     }
   }
 
@@ -75,7 +75,7 @@ class TipoMovController {
       if (!tipoMov) {
         return res
           .status(404)
-          .json({ mensagem: 'Tipo de movimento não encontrado!' });
+          .json({ mensagem: "Tipo de movimento não encontrado!" });
       }
 
       res.status(200).json(tipoMov);
@@ -83,15 +83,15 @@ class TipoMovController {
       console.log(error.message);
       res
         .status(500)
-        .json({ erro: 'Não foi possível listar o tipo de movimento.' });
+        .json({ erro: "Não foi possível listar o tipo de movimento." });
     }
   }
 
   async atualizar(req, res) {
     try {
-      await body('nome_tipo_mov')
+      await body("nome_tipo_mov")
         .notEmpty()
-        .withMessage('Informe o nome do tipo de movimento.')
+        .withMessage("Informe o nome do tipo de movimento.")
         .run(req);
 
       const errors = validationResult(req);
@@ -105,7 +105,7 @@ class TipoMovController {
       if (!tipoMov) {
         return res
           .status(404)
-          .json({ mensagem: 'Tipo de movimento não encontrado!' });
+          .json({ mensagem: "Tipo de movimento não encontrado!" });
       }
 
       const tipoMovExistente = await TipoMov.findOne({
@@ -118,16 +118,16 @@ class TipoMovController {
       if (tipoMovExistente) {
         return res
           .status(409)
-          .json({ mensagem: 'Tipo de movimento já cadastrado!' });
+          .json({ mensagem: "Tipo de movimento já cadastrado!" });
       }
 
       await tipoMov.update(req.body);
       await tipoMov.save();
-      res.status(200).json({ mensagem: 'Alteração efetuada com sucesso!' });
+      res.status(200).json({ mensagem: "Alteração efetuada com sucesso!" });
     } catch (error) {
       res
         .status(500)
-        .json({ erro: 'Não foi possível atualizar o tipo de movimento.' });
+        .json({ erro: "Não foi possível atualizar o tipo de movimento." });
     }
   }
 
@@ -146,23 +146,23 @@ class TipoMovController {
       if (!tipoMov) {
         return res
           .status(404)
-          .json({ mensagem: 'Tipo de movimento não encontrado!' });
+          .json({ mensagem: "Tipo de movimento não encontrado!" });
       }
 
       if (classeVinculada) {
         return res.status(400).json({
-          erro: 'Este tipo de movimento está vinculado a uma classe e não pode ser excluído.',
+          erro: "Este tipo de movimento está vinculado a uma classe e não pode ser excluído.",
         });
       }
 
       await tipoMov.destroy();
       res
         .status(200)
-        .json({ mensagem: 'Tipo de movimento excluído com sucesso!' });
+        .json({ mensagem: "Tipo de movimento excluído com sucesso!" });
     } catch (error) {
       res
         .status(500)
-        .json({ erro: 'Não foi possível excluir o tipo de movimento.' });
+        .json({ erro: "Não foi possível excluir o tipo de movimento." });
     }
   }
 }


### PR DESCRIPTION
 PASS  Tests/unit/contaControllerErrors.test.js
  Erros no ContaController
    √ deve retornar 400 ao tentar cadastrar sem nome (15 ms)                                                            
    √ deve retornar 409 ao tentar cadastrar com descricao já existente (16 ms)                                          
    √ deve retornar 500 ao ocorrer um erro interno no cadastro (8 ms)
    √ deve retornar 404 ao tentar listar uma conta inexistente (5 ms)
    √ deve retornar 500 ao ocorrer um erro interno na busca de uma conta (4 ms)
    √ deve retornar 404 ao tentar excluir uma conta inexistente (11 ms)
    √ deve retornar 500 ao ocorrer um erro interno na exclusão (6 ms)

Test Suites: 1 passed, 1 total
Tests:       7 passed, 7 total
Snapshots:   0 total
Time:        1.65 s, estimated 2 s
Ran all test suites matching /contaControllerErrors.test.js/i.