### PR TITLE
Develop

### DIFF
--- a/Tests/unit/classeControllerErrors.test.js
+++ b/Tests/unit/classeControllerErrors.test.js
@@ -1,0 +1,231 @@
+const ClasseController = require("../../src/controllers/ClasseController");
+const Conta = require("../../src/models/Conta");
+const Usuario = require("../../src/models/Usuario");
+const TipoMov = require("../../src/models/TipoMov");
+const Classe = require("../../src/models/Classe");
+const Movimento = require("../../src/models/Movimento");
+
+describe("Erros no ClasseController", () => {
+  let usuarioCriado;
+  let classeCriada;
+  let tipoMovCriado;
+  let contaCriada;
+
+  beforeAll(async () => {
+    usuarioCriado = await Usuario.create({
+      id: 2,
+      nome: "Usuário Teste",
+      email: "teste@email.com",
+      senha: "12345",
+    });
+
+    tipoMovCriado = await TipoMov.create({
+      nome_tipo_mov: "Tipo Mov Teste",
+      usuario_id: usuarioCriado.id,
+    });
+  });
+
+  beforeEach(async () => {
+    jest.restoreAllMocks(); // Restaura todos os mocks antes de cada teste
+    await Classe.destroy({ where: {} }); // Limpa o banco antes de cada teste
+  });
+
+  afterAll(async () => {
+    await Classe.sequelize.close(); // Fecha conexão com o banco após os testes
+  });
+
+  it("deve retornar 400 ao tentar cadastrar sem nome da classe", async () => {
+    const req = {
+      body: {
+        nome_classe: "",
+        tipo_mov_id: tipoMovCriado.id,
+        usuario_id: usuarioCriado.id,
+      },
+    };
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    await ClasseController.cadastrar(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ errors: expect.any(Array) })
+    );
+  });
+
+  it("deve retornar 409 ao tentar cadastrar com descricao já existente", async () => {
+    await Classe.create({
+      nome_classe: "Teste",
+      tipo_mov_id: tipoMovCriado.id,
+      usuario_id: usuarioCriado.id,
+    });
+
+    const req = {
+      body: {
+        nome_classe: "Teste",
+        tipo_mov_id: tipoMovCriado.id,
+        usuario_id: usuarioCriado.id,
+      },
+    };
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    await ClasseController.cadastrar(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ mensagem: "Classe já cadastrada!" })
+    );
+  });
+
+  it("deve retornar 500 ao ocorrer um erro interno no cadastro", async () => {
+    jest.spyOn(Classe, "create").mockRejectedValue(new Error("Erro interno"));
+
+    const req = {
+      body: {
+        nome_classe: "Teste",
+        tipo_mov_id: tipoMovCriado.id,
+        usuario_id: usuarioCriado.id,
+      },
+    };
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    await ClasseController.cadastrar(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        erro: "Não foi possível cadastrar a classe.",
+      })
+    );
+  });
+
+  it("deve retornar 404 ao tentar listar uma classe inexistente", async () => {
+    const req = { params: { id: 9999 } };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    jest.spyOn(Classe, "findByPk").mockResolvedValue(null);
+
+    await ClasseController.listarUm(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ mensagem: "Classe não encontrada!" })
+    );
+  });
+
+  it("deve retornar 500 ao ocorrer um erro interno na busca de uma classe", async () => {
+    jest.spyOn(Classe, "findByPk").mockRejectedValue(new Error("Erro interno"));
+
+    const req = { params: { id: 1 } };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    await ClasseController.listarUm(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        erro: "Não foi possível listar a classe.",
+      })
+    );
+  });
+
+  it("deve retornar 404 ao tentar excluir uma classe inexistente", async () => {
+    const req = { params: { id: 9999 } };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    jest.spyOn(Classe, "findByPk").mockResolvedValue(null);
+
+    await ClasseController.excluir(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ mensagem: "Classe não encontrada!" })
+    );
+  });
+
+  it("deve retornar 500 ao ocorrer um erro interno na exclusão", async () => {
+    jest.spyOn(Classe, "findByPk").mockResolvedValue({
+      destroy: jest.fn().mockRejectedValue(new Error("Erro interno")),
+    });
+
+    const req = { params: { id: 1 } };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    await ClasseController.excluir(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        erro: "Não foi possível excluir a classe.",
+      })
+    );
+  });
+
+  it("deve impedir exclusão de classe vinculada a um movimento", async () => {
+    // tipoMovCriado = await TipoMov.create({
+    //   nome_tipo_mov: "Tipo Mov teste",
+    //   usuario_id: usuarioCriado.id,
+    // });
+
+    classeCriada = await Classe.create({
+      nome_classe: "Classe Teste",
+      usuario_id: usuarioCriado.id,
+      tipo_mov_id: tipoMovCriado.id,
+    });
+
+    contaCriada = await Conta.create({
+      nome_conta: "Conta Teste",
+      usuario_id: usuarioCriado.id,
+    });
+
+    await Movimento.create({
+      data: "05/01/2025",
+      vencimento: "05/01/2025",
+      data_pagamento: null,
+      classe_id: classeCriada.id,
+      usuario_id: usuarioCriado.id,
+      descricao: "Movimento Teste",
+      valor: 100.0,
+      conta_id: contaCriada.id,
+    });
+
+    // Tenta excluir a classe vinculada ao movimento
+    const req = { params: { id: classeCriada.id } };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    await ClasseController.excluir(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        erro: "Esta classe está vinculada a um movimento e não pode ser excluída.",
+      })
+    );
+  });
+});

--- a/src/controllers/ClasseController.js
+++ b/src/controllers/ClasseController.js
@@ -1,29 +1,29 @@
-const Classe = require('../models/Classe');
-const Movimento = require('../models/Movimento');
-const { body, validationResult } = require('express-validator');
-const { Op } = require('sequelize');
+const Classe = require("../models/Classe");
+const Movimento = require("../models/Movimento");
+const { body, validationResult } = require("express-validator");
+const { Op } = require("sequelize");
 
 class ClasseController {
   async cadastrar(req, res) {
     try {
-      await body('nome_classe')
+      await body("nome_classe")
         .notEmpty()
-        .withMessage('O nome é obrigatório')
+        .withMessage("O nome é obrigatório")
         .custom((value) => {
           if (value.trim().length === 0) {
-            throw new Error('O nome não pode conter apenas espaços em branco');
+            throw new Error("O nome não pode conter apenas espaços em branco");
           }
           return true;
         })
         .run(req);
-      await body('tipo_mov_id')
+      await body("tipo_mov_id")
         .isInt()
-        .withMessage('Informe o tipo de movimento')
+        .withMessage("Informe o tipo de movimento")
         .run(req);
 
-      await body('usuario_id')
+      await body("usuario_id")
         .isInt()
-        .withMessage('Informe o usuário')
+        .withMessage("Informe o usuário")
         .run(req);
 
       const errors = validationResult(req);
@@ -40,7 +40,7 @@ class ClasseController {
       });
 
       if (classeExistente) {
-        return res.status(409).json({ mensagem: 'Classe já cadastrada!' });
+        return res.status(409).json({ mensagem: "Classe já cadastrada!" });
       }
 
       const classe = await Classe.create(req.body);
@@ -50,7 +50,7 @@ class ClasseController {
       console.log(error.message);
       res
         .status(500)
-        .json({ erro: 'Não foi possível efetuar o cadastro da classe.' });
+        .json({ erro: "Não foi possível efetuar o cadastro da classe." });
     }
   }
 
@@ -59,7 +59,7 @@ class ClasseController {
       const classes = await Classe.findAll();
       res.status(200).json(classes);
     } catch (error) {
-      res.status(500).json({ erro: 'Não foi possível listar as classes.' });
+      res.status(500).json({ erro: "Não foi possível listar as classes." });
     }
   }
 
@@ -68,22 +68,26 @@ class ClasseController {
       const { id } = req.params;
       const classe = await Classe.findByPk(id);
 
+      if (!classe) {
+        return res.status(404).json({ mensagem: "Classe não encontrada!" });
+      }
+
       res.status(200).json(classe);
     } catch (error) {
       console.log(error.message);
-      res.status(500).json({ erro: 'Não foi possível listar a classe' });
+      res.status(500).json({ erro: "Não foi possível listar a classe" });
     }
   }
 
   async atualizar(req, res) {
     try {
-      await body('nome_classe')
+      await body("nome_classe")
         .notEmpty()
-        .withMessage('O nome é obrigatório')
+        .withMessage("O nome é obrigatório")
         .run(req);
-      await body('tipo_mov_id')
+      await body("tipo_mov_id")
         .isInt()
-        .withMessage('Informe o tipo de movimento')
+        .withMessage("Informe o tipo de movimento")
         .run(req);
 
       const errors = validationResult(req);
@@ -94,6 +98,10 @@ class ClasseController {
       const { id } = req.params;
       const classe = await Classe.findByPk(id);
 
+      if (!classe) {
+        return res.status(404).json({ mensagem: "Classe não encontrada!" });
+      }
+
       const classeExistente = await Classe.findOne({
         where: {
           nome_classe: req.body.nome_classe,
@@ -102,20 +110,25 @@ class ClasseController {
       });
 
       if (classeExistente) {
-        return res.status(409).json({ mensagem: 'Classe já cadastrada!' });
+        return res.status(409).json({ mensagem: "Classe já cadastrada!" });
       }
 
       await classe.update(req.body);
       await classe.save();
-      res.status(200).json({ mensagem: 'Alteração efetuada com sucesso!' });
+      res.status(200).json({ mensagem: "Alteração efetuada com sucesso!" });
     } catch (error) {
-      res.status(500).json({ erro: 'Não foi possível atualizar a classe.' });
+      res.status(500).json({ erro: "Não foi possível atualizar a classe." });
     }
   }
 
   async excluir(req, res) {
     try {
       const { id } = req.params;
+      const classe = await Classe.findByPk(id);
+
+      if (!classe) {
+        return res.status(404).json({ mensagem: "Classe não encontrada!" });
+      }
 
       const movimentoVinculado = await Movimento.findOne({
         where: {
@@ -125,15 +138,14 @@ class ClasseController {
 
       if (movimentoVinculado) {
         return res.status(400).json({
-          erro: 'Esta classe está vinculada a um movimento e não pode ser excluída.',
+          erro: "Esta classe está vinculada a um movimento e não pode ser excluída.",
         });
       }
 
-      const classe = await Classe.findByPk(id);
       await classe.destroy();
-      res.status(200).json({ mensagem: 'Classe excluída com sucesso!' });
+      res.status(200).json({ mensagem: "Classe excluída com sucesso!" });
     } catch (error) {
-      res.status(500).json({ erro: 'Não foi possível excluir a classe.' });
+      res.status(500).json({ erro: "Não foi possível excluir a classe." });
     }
   }
 }

--- a/src/controllers/ClasseController.js
+++ b/src/controllers/ClasseController.js
@@ -48,9 +48,7 @@ class ClasseController {
       res.status(201).json(classe);
     } catch (error) {
       console.log(error.message);
-      res
-        .status(500)
-        .json({ erro: "Não foi possível efetuar o cadastro da classe." });
+      res.status(500).json({ erro: "Não foi possível cadastrar a classe." });
     }
   }
 
@@ -75,7 +73,7 @@ class ClasseController {
       res.status(200).json(classe);
     } catch (error) {
       console.log(error.message);
-      res.status(500).json({ erro: "Não foi possível listar a classe" });
+      res.status(500).json({ erro: "Não foi possível listar a classe." });
     }
   }
 


### PR DESCRIPTION
 PASS  Tests/unit/classeControllerErrors.test.js
  Erros no ClasseController
    √ deve retornar 400 ao tentar cadastrar sem nome da classe (32 ms)                                                  
    √ deve retornar 409 ao tentar cadastrar com descricao já existente (37 ms)                                          
    √ deve retornar 500 ao ocorrer um erro interno no cadastro (21 ms)                                                  
    √ deve retornar 404 ao tentar listar uma classe inexistente (9 ms)                                                  
    √ deve retornar 500 ao ocorrer um erro interno na busca de uma classe (11 ms)                                       
    √ deve retornar 404 ao tentar excluir uma classe inexistente (9 ms)                                                 
    √ deve retornar 500 ao ocorrer um erro interno na exclusão (12 ms)                                                  
    √ deve impedir exclusão de classe vinculada a um movimento (179 ms)                                                 
                                                                                                                        
Test Suites: 1 passed, 1 total
Tests:       8 passed, 8 total
Snapshots:   0 total
Time:        3.805 s
Ran all test suites matching /classeControllerErrors.test.js/i.