### PR TITLE
Develop

### DIFF
--- a/Tests/integration/movimentoRoutes.test.js
+++ b/Tests/integration/movimentoRoutes.test.js
@@ -1,0 +1,228 @@
+const request = require("supertest");
+const { Server } = require("../../src/server");
+const { connection } = require("../../src/database/connection");
+const jwt = require("jsonwebtoken");
+const serverInstance = new Server();
+const Usuario = require("../../src/models/Usuario");
+const TipoMov = require("../../src/models/TipoMov");
+const Movimento = require("../../src/models/Movimento");
+const Conta = require("../../src/models/Conta");
+const Classe = require("../../src/models/Classe");
+
+describe("Testes de Integração - MovimentoController", () => {
+  let app;
+  let token;
+  let usuarioCriado;
+  let classeCriada;
+  let tipoMovCriado;
+  let contaCriada;
+
+  beforeAll(async () => {
+    app = serverInstance.getApp(); // Obtenha o app (servidor Express)
+    await connection.sync({ force: true }); // Limpa o banco e recria as tabelas
+
+    usuarioCriado = await Usuario.create({
+      nome: "Usuário Teste",
+      email: "teste@email.com",
+      senha: "12345",
+    });
+    token = jwt.sign(
+      { id: usuarioCriado.id, nome: usuarioCriado.nome },
+      process.env.SECRET_JWT,
+      { expiresIn: "5h" }
+    );
+  });
+
+  beforeEach(async () => {
+    await connection.sync({ force: true }); // Limpa o banco antes de cada teste
+    usuarioCriado = await Usuario.create({
+      nome: "Usuário Teste",
+      email: "teste@email.com",
+      senha: "12345",
+    });
+
+    tipoMovCriado = await TipoMov.create({
+      nome_tipo_mov: "Tipo Mov Teste",
+      usuario_id: usuarioCriado.id,
+    });
+
+    classeCriada = await Classe.create({
+      nome_classe: "Classe Teste",
+      usuario_id: usuarioCriado.id,
+      tipo_mov_id: tipoMovCriado.id,
+    });
+
+    contaCriada = await Conta.create({
+      nome_conta: "Conta Teste",
+      usuario_id: usuarioCriado.id,
+    });
+  });
+
+  afterAll(async () => {
+    await connection.close(); // Fecha a conexão após os testes
+  });
+
+  // ✅ Teste de cadastro
+  describe("POST /movimento", () => {
+    it("deve cadastrar um novo movimento", async () => {
+      const response = await request(app)
+        .post("/movimento")
+        .set("Authorization", token)
+        .send({
+          data: "2025-01-08",
+          vencimento: "2025-01-08",
+          data_pagamento: null,
+          classe_id: classeCriada.id,
+          usuario_id: usuarioCriado.id,
+          descricao: "Movimento Teste",
+          valor: "100.09",
+          conta_id: contaCriada.id,
+        });
+
+      expect(response.status).toBe(201);
+      expect(response.body).toHaveProperty("descricao", "Movimento Teste");
+    });
+
+    it("deve retornar erro ao cadastrar um movimento sem data", async () => {
+      const response = await request(app)
+        .post("/movimento")
+        .set("Authorization", token)
+        .send({
+          data: "",
+          vencimento: "2025-01-08",
+          data_pagamento: null,
+          classe_id: classeCriada.id,
+          usuario_id: usuarioCriado.id,
+          descricao: "Movimento Teste",
+          valor: "100.09",
+          conta_id: contaCriada.id,
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.errors[0].msg).toBe(
+        "Insira uma data de competência válida"
+      );
+    });
+
+    it("deve retornar erro ao cadastrar um movimento sem vencimento", async () => {
+      const response = await request(app)
+        .post("/movimento")
+        .set("Authorization", token)
+        .send({
+          data: "2025-01-08",
+          vencimento: "",
+          data_pagamento: null,
+          classe_id: classeCriada.id,
+          usuario_id: usuarioCriado.id,
+          descricao: "Movimento Teste",
+          valor: "100.09",
+          conta_id: contaCriada.id,
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.errors[0].msg).toBe(
+        "Insira uma data de vencimento válida"
+      );
+    });
+
+    it("deve retornar erro ao cadastrar sem uma classe", async () => {
+      const response = await request(app)
+        .post("/movimento")
+        .set("Authorization", token)
+        .send({
+          data: "2025-01-08",
+          vencimento: "2025-01-08",
+          data_pagamento: null,
+          classe_id: "",
+          usuario_id: usuarioCriado.id,
+          descricao: "Movimento Teste",
+          valor: "100.09",
+          conta_id: contaCriada.id,
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.errors[0].msg).toBe(
+        "Selecione uma classe"
+      );
+    });
+
+    it("deve retornar erro ao cadastrar sem um valor", async () => {
+      const response = await request(app)
+        .post("/movimento")
+        .set("Authorization", token)
+        .send({
+          data: "2025-01-08",
+          vencimento: "2025-01-08",
+          data_pagamento: null,
+          classe_id: classeCriada.id,
+          usuario_id: usuarioCriado.id,
+          descricao: "Movimento Teste",
+          valor: "",
+          conta_id: contaCriada.id,
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.errors[0].msg).toBe(
+        "O valor deve ser inserido"
+      );
+    });
+  });
+
+  // ✅ Teste de listar todos
+  describe("GET /movimento", () => {
+    it("deve listar todos os movimentos", async () => {
+      const response = await request(app)
+        .get("/movimento")
+        .set("Authorization", token);
+
+      expect(response.status).toBe(200);
+      expect(Array.isArray(response.body)).toBe(true);
+    });
+  });
+
+  // ✅ Teste de listar um
+  describe("GET /movimento/:id", () => {
+    it("deve retornar erro se o movimento não for encontrado", async () => {
+      const response = await request(app)
+        .get("/movimento/999")
+        .set("Authorization", token);
+
+      expect(response.status).toBe(404);
+      expect(response.body).toHaveProperty(
+        "mensagem",
+        "Movimento não encontrado!"
+      );
+    });
+  });
+
+  // ✅ Teste de atualização
+  describe("PUT /movimento/:id", () => {
+    it("deve retornar erro ao tentar atualizar um movimento inexistente", async () => {
+      const response = await request(app)
+        .put("/movimento/999")
+        .set("Authorization", token)
+        .send({ descricao: "Novo Nome" });
+
+      expect(response.status).toBe(404);
+      expect(response.body).toHaveProperty(
+        "mensagem",
+        "Movimento não encontrado!"
+      );
+    });
+  });
+
+  // ✅ Teste de exclusão
+  describe("DELETE /movimento/:id", () => {
+    it("deve retornar erro ao tentar excluir um movimento inexistente", async () => {
+      const response = await request(app)
+        .delete("/movimento/999")
+        .set("Authorization", token);
+
+      expect(response.status).toBe(404);
+      expect(response.body).toHaveProperty(
+        "mensagem",
+        "Movimento não encontrado!"
+      );
+    });
+  });
+});

--- a/Tests/unit/movimentoControllerErrors.test.js
+++ b/Tests/unit/movimentoControllerErrors.test.js
@@ -1,0 +1,300 @@
+const MovimentoController = require("../../src/controllers/MovimentoController");
+const Movimento = require("../../src/models/Movimento");
+const Classe = require("../../src/models/Classe");
+const Usuario = require("../../src/models/Usuario");
+const TipoMov = require("../../src/models/TipoMov");
+const Conta = require("../../src/models/Conta");
+
+describe("Erros MovimentoController", () => {
+  let usuarioCriado;
+  let tipoMovCriado;
+  let contaCriada;
+
+  beforeAll(async () => {
+    usuarioCriado = await Usuario.create({
+      id: 2,
+      nome: "Usuário Teste",
+      email: "teste@email.com",
+      senha: "12345",
+    });
+
+    tipoMovCriado = await TipoMov.create({
+      nome_tipo_mov: "Tipo Mov Teste",
+      usuario_id: usuarioCriado.id,
+    });
+
+    classeCriada = await Classe.create({
+      nome_classe: "Classe Teste",
+      usuario_id: usuarioCriado.id,
+      tipo_mov_id: tipoMovCriado.id,
+    });
+
+    contaCriada = await Conta.create({
+      nome_conta: "Conta Teste",
+      usuario_id: usuarioCriado.id,
+    });
+  });
+
+  beforeEach(async () => {
+    await Movimento.destroy({ where: {} });
+  });
+
+  afterAll(async () => {
+    await Movimento.sequelize.close();
+  });
+
+  it("deve retornar 400 ao tentar cadastrar um movimento sem data", async () => {
+    const req = {
+      body: {
+        data: "",
+        vencimento: "2025-01-08",
+        data_pagamento: null,
+        classe_id: classeCriada.id,
+        usuario_id: usuarioCriado.id,
+        descricao: "Movimento Teste",
+        valor: "100.09",
+        conta_id: contaCriada.id,
+      },
+    };
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    await MovimentoController.cadastrar(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ errors: expect.any(Array) })
+    );
+  });
+
+  it("deve retornar 400 ao tentar cadastrar um movimento sem vencimento", async () => {
+    const req = {
+      body: {
+        data: "2025-01-08",
+        vencimento: "",
+        data_pagamento: null,
+        classe_id: classeCriada.id,
+        usuario_id: usuarioCriado.id,
+        descricao: "Movimento Teste",
+        valor: "100.09",
+        conta_id: contaCriada.id,
+      },
+    };
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    await MovimentoController.cadastrar(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ errors: expect.any(Array) })
+    );
+  });
+
+  it("deve retornar 400 ao tentar cadastrar um movimento sem classe", async () => {
+    const req = {
+      body: {
+        data: "2025-01-08",
+        vencimento: "2025-01-08",
+        data_pagamento: null,
+        classe_id: "",
+        usuario_id: usuarioCriado.id,
+        descricao: "Movimento Teste",
+        valor: "100.09",
+        conta_id: contaCriada.id,
+      },
+    };
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    await MovimentoController.cadastrar(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ errors: expect.any(Array) })
+    );
+  });
+
+  it("deve retornar 400 ao tentar cadastrar um movimento sem valor", async () => {
+    const req = {
+      body: {
+        data: "2025-01-08",
+        vencimento: "2025-01-08",
+        data_pagamento: null,
+        classe_id: classeCriada.id,
+        usuario_id: usuarioCriado.id,
+        descricao: "Movimento Teste",
+        valor: "",
+        conta_id: contaCriada.id,
+      },
+    };
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    await MovimentoController.cadastrar(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ errors: expect.any(Array) })
+    );
+  });
+
+  it("deve retornar 409 ao tentar cadastrar movimento já existente", async () => {
+    await Movimento.create({
+      data: "2025-01-08",
+      vencimento: "2025-01-08",
+      data_pagamento: null,
+      classe_id: classeCriada.id,
+      usuario_id: usuarioCriado.id,
+      descricao: "Movimento Teste",
+      valor: "100.99",
+      conta_id: contaCriada.id,
+    });
+
+    const req = {
+      body: {
+        data: "2025-01-08",
+        vencimento: "2025-01-08",
+        data_pagamento: null,
+        classe_id: classeCriada.id,
+        usuario_id: usuarioCriado.id,
+        descricao: "Movimento Teste",
+        valor: "100.99",
+        conta_id: contaCriada.id,
+      },
+    };
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    await MovimentoController.cadastrar(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ mensagem: "Movimento já cadastrado!" })
+    );
+  });
+
+  it("deve retornar 500 ao ocorrer um erro interno no cadastro", async () => {
+    jest
+      .spyOn(Movimento, "create")
+      .mockRejectedValue(new Error("Erro interno"));
+
+    const req = {
+      body: {
+        data: "2025-01-08",
+        vencimento: "2025-01-08",
+        data_pagamento: null,
+        classe_id: classeCriada.id,
+        usuario_id: usuarioCriado.id,
+        descricao: "Movimento Teste",
+        valor: "100.99",
+        conta_id: contaCriada.id,
+      },
+    };
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    await MovimentoController.cadastrar(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        erro: "Não foi possível efetuar o cadastro.",
+      })
+    );
+  });
+
+  it("deve retornar 404 ao tentar listar um movimento inexistente", async () => {
+    const req = { params: { id: 9999 } };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    jest.spyOn(Movimento, "findByPk").mockResolvedValue(null);
+
+    await MovimentoController.listarUm(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ mensagem: "Movimento não encontrado!" })
+    );
+  });
+
+  it("deve retornar 500 ao ocorrer um erro interno na busca de um movimento", async () => {
+    jest
+      .spyOn(Movimento, "findByPk")
+      .mockRejectedValue(new Error("Erro interno"));
+
+    const req = { params: { id: 1 } };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    await MovimentoController.listarUm(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        erro: "Não foi possível listar o movimento.",
+      })
+    );
+  });
+
+  it("deve retornar 404 ao tentar excluir um movimento inexistente", async () => {
+    const req = { params: { id: 9999 } };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    jest.spyOn(Movimento, "findByPk").mockResolvedValue(null);
+
+    await MovimentoController.excluir(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ mensagem: "Movimento não encontrado!" })
+    );
+  });
+
+  it("deve retornar 500 ao ocorrer um erro interno na exclusão", async () => {
+    jest.spyOn(Movimento, "findByPk").mockResolvedValue({
+      destroy: jest.fn().mockRejectedValue(new Error("Erro interno")),
+    });
+
+    const req = { params: { id: 1 } };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    await MovimentoController.excluir(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        erro: "Não foi possível excluir o movimento.",
+      })
+    );
+  });
+});

--- a/src/controllers/MovimentoController.js
+++ b/src/controllers/MovimentoController.js
@@ -41,6 +41,22 @@ class MovimentoController {
         return res.status(400).json({ errors: errors.array() });
       }
 
+      const { data, vencimento, classe_id, valor } = req.body;
+
+      const movimentoExistente = await Movimento.findOne({
+        where: {
+          data: data,
+          vencimento: vencimento,
+          classe_id: classe_id,
+          valor: valor,
+        },
+      });
+
+      if (movimentoExistente) {
+        return res.status(409).json({
+           mensagem: "Movimento já cadastrado!" });
+      }
+
       const movimento = await Movimento.create(req.body);
 
       res.status(201).json(movimento);
@@ -66,8 +82,8 @@ class MovimentoController {
       const { id } = req.params;
       const movimento = await Movimento.findByPk(id);
 
-      if(!movimento) {
-        return res.status(404).json({ mensagem: "Movimento não encontrado!"})
+      if (!movimento) {
+        return res.status(404).json({ mensagem: "Movimento não encontrado!" });
       }
 
       res.status(200).json(movimento);
@@ -82,8 +98,8 @@ class MovimentoController {
       const { id } = req.params;
       const movimento = await Movimento.findByPk(id);
 
-      if(!movimento) {
-        return res.status(404).json({ mensagem: "Movimento não encontrado!"})
+      if (!movimento) {
+        return res.status(404).json({ mensagem: "Movimento não encontrado!" });
       }
 
       await movimento.update(req.body);
@@ -99,8 +115,8 @@ class MovimentoController {
       const { id } = req.params;
       const movimento = await Movimento.findByPk(id);
 
-      if(!movimento) {
-        return res.status(404).json({ mensagem: "Movimento não encontrado!"})
+      if (!movimento) {
+        return res.status(404).json({ mensagem: "Movimento não encontrado!" });
       }
 
       await movimento.destroy();

--- a/src/controllers/MovimentoController.js
+++ b/src/controllers/MovimentoController.js
@@ -66,6 +66,10 @@ class MovimentoController {
       const { id } = req.params;
       const movimento = await Movimento.findByPk(id);
 
+      if(!movimento) {
+        return res.status(404).json({ mensagem: "Movimento não encontrado!"})
+      }
+
       res.status(200).json(movimento);
     } catch (error) {
       console.log(error.message);
@@ -77,6 +81,10 @@ class MovimentoController {
     try {
       const { id } = req.params;
       const movimento = await Movimento.findByPk(id);
+
+      if(!movimento) {
+        return res.status(404).json({ mensagem: "Movimento não encontrado!"})
+      }
 
       await movimento.update(req.body);
       await movimento.save();
@@ -90,6 +98,10 @@ class MovimentoController {
     try {
       const { id } = req.params;
       const movimento = await Movimento.findByPk(id);
+
+      if(!movimento) {
+        return res.status(404).json({ mensagem: "Movimento não encontrado!"})
+      }
 
       await movimento.destroy();
       res.status(200).json({ mensagem: "Movimento excluído com sucesso!" });


### PR DESCRIPTION
 PASS  Tests/unit/movimentoControllerErrors.test.js
  Erros MovimentoController                                                                                             
    √ deve retornar 400 ao tentar cadastrar um movimento sem data (17 ms)                                               
    √ deve retornar 400 ao tentar cadastrar um movimento sem vencimento (10 ms)                                         
    √ deve retornar 400 ao tentar cadastrar um movimento sem classe (6 ms)                                              
    √ deve retornar 400 ao tentar cadastrar um movimento sem valor (7 ms)                                               
    √ deve retornar 409 ao tentar cadastrar movimento já existente (20 ms)                                              
    √ deve retornar 500 ao ocorrer um erro interno no cadastro (10 ms)                                                  
    √ deve retornar 404 ao tentar listar um movimento inexistente (4 ms)                                                
    √ deve retornar 500 ao ocorrer um erro interno na busca de um movimento (5 ms)                                      
    √ deve retornar 404 ao tentar excluir um movimento inexistente (4 ms)                                               
    √ deve retornar 500 ao ocorrer um erro interno na exclusão (4 ms)                                                   
                                                                                                                        
Test Suites: 1 passed, 1 total
Tests:       10 passed, 10 total
Snapshots:   0 total
Time:        1.669 s, estimated 2 s
Ran all test suites matching /movimentoControllerErrors.test.js/i.